### PR TITLE
fix CMD_DURATION variable not set problem

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -15,12 +15,13 @@ function fish_right_prompt
         set status_color f00
     end
 
-    if test "$CMD_DURATION" -gt 100
+    set __cmd_duration $CMD_DURATION 0
+    if test "$__cmd_duration" -gt 100
         if test ! -z "$status_code"
             echo -sn (set_color $status_color) "$status_code ╱" (set_color normal)
         end
 
-        set -l duration (echo $CMD_DURATION | humanize_duration)
+        set -l duration (echo $__duration | humanize_duration)
         echo -sn (set_color $status_color) " $duration " (set_color normal)
         set status_glyph ┃
     else


### PR DESCRIPTION
Fix the "invalid precision" exception, which is caused by the $CMD_DURATION variable not set.